### PR TITLE
Fix paths that use transarc locations, add compatibility packages

### DIFF
--- a/openafs.spec
+++ b/openafs.spec
@@ -672,7 +672,8 @@ fi
 %{_mandir}/man5/uss_bulk.5.gz
 %{_mandir}/man8/bos*
 %{_mandir}/man8/fstrace*
-%{_mandir}/man8/kas*
+%{_mandir}/man8/kas.*
+%{_mandir}/man8/kas_*
 %{_mandir}/man1/sys.1.gz
 %{_mandir}/man8/backup*
 %{_mandir}/man5/butc.5.gz
@@ -801,6 +802,7 @@ fi
 %{_mandir}/man8/davolserver.*
 %{_mandir}/man8/kadb_check.*
 %{_mandir}/man8/ka-forwarder.*
+%{_mandir}/man8/kaserver.*
 %{_mandir}/man8/prdb_check.*
 %{_mandir}/man8/ptserver.*
 %{_mandir}/man8/pt_util.*


### PR DESCRIPTION
These commits include:
- Fix all the transarc paths:  There are a bunch of references to transarc paths in systemd units and where files are installed that needed to be fixed to point at the system locations
- The openafs-compat subpackage is restored from upstream
- Two new subpackages are created, openafs-transarc-client, which has /usr/vice, and openafs-transarc-server, which populates /usr/afs/
- A bump up to version 1.6.10 and the inclusion of a new server executable (volscan) and its man page
- A fix that should also be pushed upstream, putting the 'kaserver' man page into the server RPM.
