### PR TITLE
openafs.spec: Make sure that library files are auto-provided

### DIFF
--- a/openafs.spec
+++ b/openafs.spec
@@ -502,6 +502,10 @@ sed -i 's!/usr/afs/bin/bosserver!%{_sbindir}/bosserver!' $RPM_BUILD_ROOT%{_unitd
 ## Fix cacheinfo to point at /var/cache/openafs
 sed -i 's!/usr/vice/cache!%{_localstatedir}/cache/openafs!' $RPM_BUILD_ROOT%{_sysconfdir}/openafs/cacheinfo
 
+# Set the executable bit on libraries in libdir, so rpmbuild knows to
+# create "Provides" entries in the package metadata for the libraries
+chmod +x $RPM_BUILD_ROOT%{_libdir}/*.so*
+
 ##############################################################################
 ###
 ### clean


### PR DESCRIPTION
The RPM find-provides script looks for library files that are
executable (chmod +x).  This change makes sure that all the library
files in libdir are executable.  The resulting RPMs will have their
library names added in the Provides: section.